### PR TITLE
Update README.md to use ParsedType.EMAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ ParsedText(
     "[@michael:51515151] Hello this is an example of the ParsedText, links like http://www.google.com or http://www.facebook.com are clickable and phone number 444-555-6666 can call too. But you can also do more with this package, for example Bob will change style and David too. foo@gmail.com And the magic number is 42! #react #react-native",
   parse: <MatchText>[
     MatchText(
-      type: "email",
+      type: ParsedType.EMAIL,
       style: TextStyle(
         color: Colors.red,
         fontSize: 24,


### PR DESCRIPTION
Hey, just a small typo fix here, to use `type: ParsedType.EMAIL` instead of `type: "email"`.