### PR TITLE
Fixed example of RegexOptions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ MatchText(
 MatchText(
   pattern: r"\B#+([\w]+)\b", // a custom pattern to match
   regexOptions: RegexOptions(
-    multiLine = false,
-    caseSensitive = false,
-    unicode = false,
-    dotAll = false
-  )
+    multiLine : false,
+    caseSensitive : false,
+    unicode : false,
+    dotAll : false
+  ),
   style: TextStyle(
     color: Colors.pink,
     fontSize: 24,


### PR DESCRIPTION
The original regexOptions example in the README.md had equal signs instead of colons, and did not have a comma at the end. This has been amended so the code runs.