### PR TITLE
fix: on tap - pass value if provided or else pass matched text

### DIFF
--- a/lib/src/parsed_text.dart
+++ b/lib/src/parsed_text.dart
@@ -151,7 +151,10 @@ class ParsedText extends StatelessWidget {
               text: "${result['display']}",
               style: mapping.style != null ? mapping.style : style,
               recognizer: TapGestureRecognizer()
-                ..onTap = () => mapping.onTap!(matchText),
+                ..onTap = () {
+                  final value = result['value'] ?? matchText;
+                  mapping.onTap?.call(value);
+                },
             );
           } else if (mapping.renderWidget != null) {
             widget = WidgetSpan(


### PR DESCRIPTION
Fixes #40 

If value is provided in `renderText` function, then onTap handler should respect that. 
As a fallback the matched text should be returned if value is not provided.