### PR TITLE
Do not consume tap events if no onTap is provided

### DIFF
--- a/lib/src/parsed_text.dart
+++ b/lib/src/parsed_text.dart
@@ -144,33 +144,51 @@ class ParsedText extends StatelessWidget {
 
         if (mapping != null) {
           if (mapping.renderText != null) {
-            Map<String, String> result =
-                mapping.renderText!(str: matchText, pattern: pattern);
+            Map<String, String> result = mapping.renderText!(str: matchText, pattern: pattern);
+
+            TapGestureRecognizer? recognizer;
+
+            if (mapping.onTap != null) {
+              recognizer = TapGestureRecognizer();
+              recognizer.onTap = () {
+                final value = result['value'] ?? matchText;
+                mapping.onTap?.call(value);
+              };
+            }
 
             widget = TextSpan(
               text: "${result['display']}",
               style: mapping.style != null ? mapping.style : style,
-              recognizer: TapGestureRecognizer()
-                ..onTap = () {
-                  final value = result['value'] ?? matchText;
-                  mapping.onTap?.call(value);
-                },
+              recognizer: recognizer,
             );
           } else if (mapping.renderWidget != null) {
+            Widget child = mapping.renderWidget!(text: matchText, pattern: mapping.pattern!);
+
+            if (mapping.onTap != null) {
+              child = GestureDetector(
+                onTap: () => mapping.onTap!(matchText),
+                child: child,
+              );
+            }
+
             widget = WidgetSpan(
               alignment: PlaceholderAlignment.middle,
-              child: GestureDetector(
-                onTap: () => mapping.onTap!(matchText),
-                child: mapping.renderWidget!(
-                    text: matchText, pattern: mapping.pattern!),
-              ),
+              child: child,
             );
           } else {
+            TapGestureRecognizer? recognizer;
+
+            if (mapping.onTap != null) {
+              recognizer = TapGestureRecognizer();
+              recognizer.onTap = () {
+                mapping.onTap!(matchText);
+              };
+            }
+
             widget = TextSpan(
               text: "$matchText",
               style: mapping.style != null ? mapping.style : style,
-              recognizer: TapGestureRecognizer()
-                ..onTap = () => mapping.onTap!(matchText),
+              recognizer: recognizer,
             );
           }
         } else {


### PR DESCRIPTION
Should fix #50 

Does not consume tap events if no on tap is provided, so they still trigger onMessage callbacks if someone just wants to change the style of matches text without removing the ability to click the message itself behind the restyled text.

